### PR TITLE
Use same ruby version in Gemfile and .ruby-version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.6.4'
+ruby '2.6.5'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,7 +273,7 @@ DEPENDENCIES
   web-console (~> 4.0.1)
 
 RUBY VERSION
-   ruby 2.6.4p104
+   ruby 2.6.5p114
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
### Problem
`.ruby-version` is requiring `ruby-2.6.4` while `Gemfile` is specifying `ruby-2.6.5`; when running `bundle install` it fails.

### Solution
Bump ruby to `2.6.5` in `Gemfile`.