### PR TITLE
Fix error when executing rails server on macOS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,4 +66,4 @@ gem 'docusign_esign', '~> 3.4.0'
 gem 'omniauth-oauth2', '~> 1.6.0'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', '~> 1.2019.3', platforms: %i[mingw mswin x64_mingw jruby]
-gem 'wdm', '>= 0.1.0'
+gem 'wdm', '>= 0.1.0', platforms: %i[mingw mswin x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,7 @@ GEM
     execjs (2.7.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
+    ffi (1.13.1)
     ffi (1.13.1-x64-mingw32)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -121,12 +122,16 @@ GEM
     method_source (0.9.2)
     mimemagic (0.3.5)
     mini_mime (1.0.2)
+    mini_portile2 (2.5.0)
     minitest (5.14.1)
+    msgpack (1.3.3)
     msgpack (1.3.3-x64-mingw32)
     multi_json (1.14.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nio4r (2.5.2)
+    nokogiri (1.11.0.rc2)
+      mini_portile2 (~> 2.5.0)
     nokogiri (1.11.0.rc2-x64-mingw32)
     oauth2 (1.4.4)
       faraday (>= 0.8, < 2.0)
@@ -187,6 +192,8 @@ GEM
     rubyzip (2.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
+    sassc (2.4.0)
+      ffi (~> 1.9)
     sassc (2.4.0-x64-mingw32)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -238,6 +245,7 @@ GEM
     zeitwerk (2.3.1)
 
 PLATFORMS
+  ruby
   x64-mingw32
 
 DEPENDENCIES


### PR DESCRIPTION
Error from running: bin/rails server
```
Traceback (most recent call last):
bin/rails: Bootsnap::LoadPathCache::FallbackScan
...
~/.asdf/installs/ruby/2.7.1/lib/ruby/gems/2.7.0/gems/wdm-0.1.1/lib/wdm.rb:4:in `rescue in <main>':     Can't load WDM! (LoadError)

    WDM is not supported on your system. For a cross-platform alternative,
    we recommend using Listen: http://github.com/guard/listen
```