### PR TITLE
One fix of local SSL issues on OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,17 @@ Modify the following two lines in the **configuration.rb** file, replacing `true
 
 Once this is complete, you can run your Ruby on Rails application again and you should be able to make API calls on your localhost.
 
+### Troubleshooting macOS SSL issue
+When using the Ruby launcher on OSX you may get the following error:
+
+```
+Faraday::SSLError (SSL_connect returned=1 errno=0 state=error: certificate verify failed (self signed certificate in certificate chain))
+```
+Please update SSL certificates if brew is your package manager. Or check [other steps for other package manager](https://gemfury.com/help/could-not-verify-ssl-certificate/#updating-ssl-certificates)
+```
+$ rvm osx-ssl-certs status all
+$ rvm osx-ssl-certs update all
+```
 
 ## Payments code example
 To use the payments code example, create a test payment gateway on the [**Payments**](https://admindemo.docusign.com/authenticate?goTo=payments) page in your developer account. See [Configure a payment gateway](./PAYMENTS_INSTALLATION.md) for details.

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ When using the Ruby launcher on OSX you may get the following error:
 ```
 Faraday::SSLError (SSL_connect returned=1 errno=0 state=error: certificate verify failed (self signed certificate in certificate chain))
 ```
-Please update SSL certificates if brew is your package manager. Or check [other steps for other package manager](https://gemfury.com/help/could-not-verify-ssl-certificate/#updating-ssl-certificates)
+Please update SSL certificates if rvm is your version manager. Or check [other steps for different scenarios](https://gemfury.com/help/could-not-verify-ssl-certificate/#updating-ssl-certificates).
 ```
 $ rvm osx-ssl-certs status all
 $ rvm osx-ssl-certs update all


### PR DESCRIPTION
Original error:
```
Faraday::SSLError (SSL_connect returned=1 errno=0 state=error: certificate verify failed (self signed certificate in certificate chain))
```
Ruby quickstarters show self signed SSL error.  Since I use RVM on OSX, I had to do "rvm osx-ssl-certs update all" before quickstart-ruby can run.